### PR TITLE
Gradle fixes

### DIFF
--- a/properties-upgrade-locator/build.gradle
+++ b/properties-upgrade-locator/build.gradle
@@ -4,6 +4,12 @@ repositories {
 	mavenCentral()
 }
 
+compileJava {
+	options.fork = true
+	options.forkOptions.executable = 'javac'
+	options.compilerArgs << "-XDignore.symbol.file"
+}
+
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.20.0"
 }

--- a/properties-upgrade-locator/build.gradle
+++ b/properties-upgrade-locator/build.gradle
@@ -6,7 +6,12 @@ repositories {
 
 compileJava {
 	options.fork = true
-	options.forkOptions.executable = 'javac'
+	
+	if (java_home)
+		options.forkOptions.javaHome = file(java_home)
+	else
+		throw new GradleException('You must set your JAVA_HOME relative path in gradle.properties file.')
+	
 	options.compilerArgs << "-XDignore.symbol.file"
 }
 

--- a/properties-upgrade-locator/gradle.properties
+++ b/properties-upgrade-locator/gradle.properties
@@ -1,0 +1,1 @@
+java_home=


### PR DESCRIPTION
Hey @achaparro 

Here you can find a fix to let the project be compiled using Gradle, being independent of the IDE.

The first commit is enough but forkOptions.executable [is deprecated since Gradle 3.5](https://docs.gradle.org/3.5/release-notes.html) and will be deleted from Gradle 5. 

That's the reason of the second commit, although this involves to set your JAVA_HOME in gradle.properties file. 

It's up to you to pick up one or both.

Thanks!

